### PR TITLE
fix wrong directory used for EE_CONF_DIR

### DIFF
--- a/io.github.daid.EmptyEpsilon.yml
+++ b/io.github.daid.EmptyEpsilon.yml
@@ -62,7 +62,7 @@ modules:
       - type: script
         commands:
           - 'if [ -z "$EE_CONF_DIR" ]; then'
-          - '	export EE_CONF_DIR=$XDG_CONFIG_HOME'
+          - '	export EE_CONF_DIR=$XDG_CONFIG_HOME/emptyepsilon'
           - 'fi'
           - 'exec EmptyEpsilon "$@"'
         dest-filename: EmptyEpsilon-wrapper


### PR DESCRIPTION
I only now realized that this one was just plain wrong, the location of config files should be e.g. `$XDG_CONFIG_HOME/emptyepsilon/options.ini` and not $XDG_CONFIG_HOME/options.ini`.